### PR TITLE
Prepare v7 release

### DIFF
--- a/mind-parent-resources/pom.xml
+++ b/mind-parent-resources/pom.xml
@@ -3,6 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- Inherit from OW2 base maven POM. Required to be able to deploy on Nexus 
+        repository. -->
+    <parent>
+        <groupId>org.ow2</groupId>
+        <artifactId>ow2</artifactId>
+        <version>1.3</version>
+    </parent>
+
     <groupId>org.ow2.mind</groupId>
     <artifactId>mind-parent-resources</artifactId>
     <version>1-SNAPSHOT</version>
@@ -14,7 +22,56 @@
         Resources for parent POM for MIND modules built with maven.
     </description>
 
+    <repositories>
+        <repository>
+            <id>OW2-release</id>
+            <name>OW2 Maven Repository</name>
+            <url>http://maven.ow2.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>OW2-snapshot</id>
+            <name>OW2 Maven SNAPSHOT Repository</name>
+            <url>http://maven.ow2.org/maven2-snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <properties>
+        <!-- The login name on the OW2 Forge (default is local user name, may be 
+            overridden on the command line or in settings.xml file). -->
+        <ow2.username>${user.name}</ow2.username>
+        <ow2.hostname>forge.ow2.org</ow2.hostname>
+        <ow2.site.deploy.dir>/var/lib/gforge/chroot/home/groups/mind/htdocs</ow2.site.deploy.dir>
+    </properties>
+
+    <distributionManagement>
+        <site>
+            <id>OW2</id>
+            <name>MIND OW2's site</name>
+            <url>scp://${ow2.hostname}${ow2.site.deploy.dir}/mind-parent-resources-${project.version}</url>
+        </site>
+    </distributionManagement>
+
     <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>2.2</version>
+            </extension>
+        </extensions>
         <plugins>
             <!-- Following plugins are not inherited to children -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -81,14 +81,14 @@
         <!-- The login name on the OW2 Forge (default is local user name, may be 
             overridden on the command line or in settings.xml file). -->
         <ow2.username>${user.name}</ow2.username>
-        <ow2.hostname>forge.objectweb.org</ow2.hostname>
+        <ow2.hostname>forge.ow2.org</ow2.hostname>
         <ow2.site.deploy.dir>/var/lib/gforge/chroot/home/groups/mind/htdocs</ow2.site.deploy.dir>
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/MIND-Tools/maven/tree/master/mind-parent</connection>
-        <developerConnection>scm:git:https://github.com/MIND-Tools/maven/tree/master/mind-parent</developerConnection>
-        <url>https://github.com/MIND-Tools/maven/tree/master/mind-parent</url>
+        <connection>scm:git:https://github.com/MIND-Tools/mind-parent</connection>
+        <developerConnection>scm:git:https://github.com/MIND-Tools/mind-parent</developerConnection>
+        <url>https://github.com/MIND-Tools/mind-parent</url>
     </scm>
 
     <mailingLists>


### PR DESCRIPTION
# Prepare v7 release
## mind-parent
- Development web server URL fix
- SCM URLs fix
## mind-parent-resources
- Inherit from OW2 parent to allow staging / release
- Maven repository configuration (not inherited from mind-parent here)
- SSH configuration to allow publication on the development web server
